### PR TITLE
SPViewController will not initialize if "initWithCoder:" is called

### DIFF
--- a/sparrow/src/Classes/SPViewController.m
+++ b/sparrow/src/Classes/SPViewController.m
@@ -64,21 +64,41 @@
 {
     if ((self = [super initWithNibName:nibNameOrNil bundle:nibBundleOrNil]))
     {
-        _contentScaleFactor = 1.0f;
-        _stage = [[SPStage alloc] init];
-        _juggler = [[SPJuggler alloc] init];
-        _touchProcessor = [[SPTouchProcessor alloc] initWithRoot:_stage];
-        _programs = [[NSMutableDictionary alloc] init];
-        _context = [[EAGLContext alloc] initWithAPI:kEAGLRenderingAPIOpenGLES2];
-        _support = [[SPRenderSupport alloc] init];
-        
-        if (!_context || ![EAGLContext setCurrentContext:_context])
-            NSLog(@"Could not create render context");
-        
-        [Sparrow setCurrentController:self];
+        [self setup];
     }
-    
     return self;
+}
+
+- (id)initWithCoder:(NSCoder *)aDecoder
+{
+    if ((self = [super initWithCoder:aDecoder])) {
+        [self setup];
+    }
+    return self;
+}
+
+- (id)init
+{
+    if ((self = [super init])) {
+        [self setup];
+    }
+    return self;
+}
+
+- (void)setup
+{
+    _contentScaleFactor = 1.0f;
+    _stage = [[SPStage alloc] init];
+    _juggler = [[SPJuggler alloc] init];
+    _touchProcessor = [[SPTouchProcessor alloc] initWithRoot:_stage];
+    _programs = [[NSMutableDictionary alloc] init];
+    _context = [[EAGLContext alloc] initWithAPI:kEAGLRenderingAPIOpenGLES2];
+    _support = [[SPRenderSupport alloc] init];
+    
+    if (!_context || ![EAGLContext setCurrentContext:_context])
+        NSLog(@"Could not create render context");
+    
+    [Sparrow setCurrentController:self];
 }
 
 - (void)viewDidLoad


### PR DESCRIPTION
When using storyboards for a project, the method "initWithCoder:" is called instead of "initWithNibName:bundle:"
So my project was crashing because the stage was not allocated, the juggler was not allocated, touch processor, programs, context, render support... were all not allocated.
