### PR TITLE
Fixed SPQuad resizing bug

### DIFF
--- a/sparrow/src/Classes/SPQuad.m
+++ b/sparrow/src/Classes/SPQuad.m
@@ -174,6 +174,22 @@
     [support batchQuad:self];
 }
 
+- (void)setWidth:(float)width
+{
+    _vertexData.vertices[1].position.x = width;
+    _vertexData.vertices[3].position.x = width;
+    [self vertexDataDidChange];
+    [super setWidth:width];
+}
+
+- (void)setHeight:(float)height
+{
+    _vertexData.vertices[2].position.y = height;
+    _vertexData.vertices[3].position.y = height;
+    [self vertexDataDidChange];
+    [super setHeight:height];
+}
+
 + (id)quadWithWidth:(float)width height:(float)height
 {
     return [[self alloc] initWithWidth:width height:height];


### PR DESCRIPTION
I discovered this bug when I created an SPTextField with height 0 and then set it to a height > 0. It wasn't visible and it reported its height as 0. I traced this issue to SPQuad.

If you create a quad with width or height = 0 and then set it to > 0 later, it does not update. The quad is effectively invisible. One would expect that the quad would be resized correctly even when initialized with height = 0.

This change fixes that bug by resetting the vertexData involving width and height when the width or height of a quad changes.
