### PR TITLE
SPDisplayObjectContainer children property

### DIFF
--- a/sparrow/src/Classes/SPDisplayObjectContainer.h
+++ b/sparrow/src/Classes/SPDisplayObjectContainer.h
@@ -111,5 +111,6 @@
 /// The number of children of this container.
 @property (nonatomic, readonly) int numChildren;
 
+@property (nonatomic, readonly) NSArray *children;
 
 @end

--- a/sparrow/src/Classes/SPDisplayObjectContainer.m
+++ b/sparrow/src/Classes/SPDisplayObjectContainer.m
@@ -39,6 +39,8 @@ static void getChildEventListeners(SPDisplayObject *object, NSString *eventType,
     NSMutableArray *_children;
 }
 
+@synthesize children = _children;
+
 - (id)init
 {    
     #if DEBUG    


### PR DESCRIPTION
When trying to iterate through all children of the render tree I realized that there was no children property in SPDisplayObjectContainer.

I didn't feel like doing the whole "for uint i=0 ... i<numchildren ... object.childAtIndex:i ...." in several places. That was the motivation for the change.

With this change there is no fear of giving access to private _children data because an NSArray is being returned, as opposed to an NSMutableArray.
Which means that other objects getting the children can't add or remove objects inside the array without the display object container knowing about it.
It's also a readonly property so there is no fear of someone attempting a Tomb Raider style swap of children arrays.
