### PR TITLE
Fixed bug in SPDisplayObject

### DIFF
--- a/sparrow/src/Classes/SPDisplayObject.m
+++ b/sparrow/src/Classes/SPDisplayObject.m
@@ -131,7 +131,7 @@ float square(float value) { return value * value; }
     // Instead of using an NSSet or NSArray (which would make the code much cleaner), we 
     // use a C array here to save the ancestors.
     
-    static SPDisplayObject *ancestors[SP_MAX_DISPLAY_TREE_DEPTH];
+    static SPDisplayObject *__weak ancestors[SP_MAX_DISPLAY_TREE_DEPTH];
     
     int count = 0;
     SPDisplayObject *commonParent = nil;


### PR DESCRIPTION
I guess the problem popped up during the change to ARC.
SPDisplayObject contains a static array of ancestors in the "transformationMatrixToSpace:" function which prevents SPStage from being deallocated since (now with ARC) it is retained when SPStage is put in the array.
Before the migration to ARC it was all fine since objects were being added to the array without an explicit retain call.

It is debatable whether __weak, __unsafe_unretained, or __autoreleasing should be used in this case. Weak was just the first one that came to mind.
