### PR TITLE
Fix for storing shader uniform and attrib location

### DIFF
--- a/sparrow/src/Classes/SPProgram.m
+++ b/sparrow/src/Classes/SPProgram.m
@@ -140,7 +140,7 @@
     {
         glGetActiveUniform(_name, i, MAX_NAME_LENGTH, NULL, NULL, NULL, rawName);
         NSString *name = [[NSString alloc] initWithCString:rawName encoding:NSUTF8StringEncoding];
-        _uniforms[name] = @(i);
+        _uniforms[name] = @(glGetUniformLocation(_name, rawName));
     }
 }
 
@@ -158,7 +158,7 @@
     {
         glGetActiveAttrib(_name, i, MAX_NAME_LENGTH, NULL, NULL, NULL, rawName);
         NSString *name = [[NSString alloc] initWithCString:rawName encoding:NSUTF8StringEncoding];
-        _attributes[name] = @(i);
+        _attributes[name] = @(glGetAttribLocation(_name, rawName));
     }
 }
 


### PR DESCRIPTION
Currently, `SPProgram` uses the uniform name index as the program location for the uniform. While this works (through coincidence) on iOS 5 and 6, it breaks for iOS 7 preview 2, causing the call to `glUniformMatrix4fv` in `SPBaseEffect.m:97` to fail with a `GL_INVALID_OPERATION` error due to the wrong location being used.

The fix is to use `glGetUniformLocation` and `glGetAttribLocation` to fetch the correct locations for the inputs from the input name.

The fix was tested with a trivial program showing a textured sprite and untextured quad which now works on both iOS 6.1 and iOS 7 DP2 (unfortunately I don't have any iOS 5 devices to hand). Unit tests also pass of course.
