### PR TITLE
Resolving dropped/lost intra-frame rapid touches 

### DIFF
--- a/sparrow/src/Classes/SPTouchProcessor.m
+++ b/sparrow/src/Classes/SPTouchProcessor.m
@@ -123,7 +123,6 @@
         NSMutableArray* excessQueue = [NSMutableArray array];
         NSSet* touchIDs = [NSSet setWithArray:[_queuedTouches valueForKey:@"touchID"]];
         NSMutableIndexSet *excessQueueIndexes = [[NSMutableIndexSet alloc] init];
-        
         for(NSNumber* touchID in touchIDs)
         {
             int dupCount = 0;


### PR DESCRIPTION
I’ve been dealing with an issue of dropped/lost touches.  I’m working on an app that allows for extremely rapid multiple touches.

A situation exists now in SPTouchProcessor, where when a touch’s phase changes within the period of a single frame, the last phase overwrites the previous.  This may mean that you only get SPTouchPhaseEnded without ever seeing the initial SPTouchPhaseBegan.  That represents a dropped touch.  Of course, you really have to tap fast in order to re-create this issue.  It’s easy to see if the frame rate drops a bit and you’re on a slower device. 

I’m really interested to see if anyone can solve this issue in a better and more optimized way.

I’ve tried a few approaches but this one seemed to work the best.

[ Move any matching touches onto a temporary queue.  Dispatch the normal queue as usually and then, right after, reprocess the matching touches queue before the next frame.  Even though you’ll see these touches fire out at nearly the same time, the point is that all phases still fire and in the correct order. ] 

Before we merge this, I’d really like some feedback about performance.  I’m guessing there is either a better approach or at least, way to improve the performance.
 
Thanks in advance.

