### PR TITLE
I think the usage of __block inside SPTexture.m may be wrong (causes crash for me)

### DIFF
--- a/sparrow/src/Classes/SPTexture.m
+++ b/sparrow/src/Classes/SPTexture.m
@@ -347,7 +347,7 @@ static SP_GENERIC(SPCache, NSString*, SPTexture*) *textureCache = nil;
      {
          [Sparrow.currentController executeInResourceQueue:^
           {
-              __block NSError *loadError = nil;
+              NSError *loadError = nil;
               NSString *cacheKey = [url absoluteString];
               SPTexture *texture = [textureCache[cacheKey] retain];
               GLsync waitUntilTextureLoaded = nil;


### PR DESCRIPTION
Upon upgrading to Xcode 7.3, I suddenly started to get `EXC_BAD_ACCESS` crashes when `[SPTexture loadFromURL:onComplete:]` requests fail. The easiest way to reproduce this error, for me, is to comment out line 384 of SPTexture.m:

	// if (!body)
		[NSException raise:SPExceptionOperationFailed
		            format:@"couldn't load resource at %@", url.absoluteString];

This simulates the effect of receiving, say, an HTML page of a 404 error instead of image data.

On my system, the app then dies -- most of the time -- with an `EXC_BAD_ACCESS`. Sometimes it will survive, however, turning on Zombie Objects produces an `EXC_BREAKPOINT` consistently.

More specifically the variable `loadError` is deallocated before its usage inside the `dispatch_async` block. I think this is because the variable is erroneously declared as `__block`. [This stackoverflow question](http://stackoverflow.com/q/10804865/) deals with someone else with the same issue.

I took the `__block` keyword out as the question answer says, and suddenly my crash is gone.